### PR TITLE
Add the `add-all` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ to see if you need to update or push any of them.
 ## Usage
 1. Create a list of git repositories. You can do this easily by navigating to 
 each directory and calling `systemgit add`. The path is saved in the 
-`$HOME/.gitrepos` file. To remove a repository, simply call `systemgit remove` 
+`$HOME/.gitrepos` file. If you have many git repositories within a parent
+directory, you can use `systemgit add-all` to find and add them all, regardless
+of how deeply nested they may be. To remove a repository, simply call `systemgit remove` 
 from the repository directory. Of course, you can always modify `.gitrepos`
 manually.
 2. Call `systemgit` or `systemgit show` to view the status of all the 
@@ -23,4 +25,5 @@ repositories you've added to the `.gitrepos` list.
 ## Tips
 * `systemgit help` displays the help message.
 * When you first set up the system, you can begin with `find $HOME -name ".git"`
-to get a list of repositories within your home directory
+to get a list of repositories within your home directory. Or you can just run
+`systemgit add-all` from your home directory to add them all automatically!

--- a/systemgit.sh
+++ b/systemgit.sh
@@ -114,12 +114,14 @@ showRepoStatus () {
 
 showHelp(){
 	echo "Usage: systemgit"
-	echo "       systemgit [show | add | remove]\n"
+	echo "       systemgit [show | add | add-all | remove]\n"
 
 	echo "Arguments:"
-	echo "  show:   show the status of all tracked repositories"
-	echo "  add:    add the current directory as a tracked repository"
-	echo "  remove: remove the current directory from being tracked"
+	echo "  show:    show the status of all tracked repositories"
+	echo "  add:     add the current directory as a tracked repository"
+	echo "  add-all: add all git repositories within the current directory as"
+	echo "           tracked repositories"
+	echo "  remove:  remove the current directory from being tracked"
 }
 
 # ------------------------------------------------------------------------------
@@ -167,6 +169,11 @@ case $action in
 		# We've passed the checks, add the repo to the list
 		echo $path >> $REPO_LIST
 		echo "Added $path"
+		;;
+	add-all) # add all repos within the current directory to the list
+		# $0 is the full path to this script, so this essentially just runs
+		# 'systemgit add' from each git repo found
+		find "$path" -name .git -type d -execdir "$0" add \;
 		;;
 	remove) # remove a repo from the list
 		isInRepoList $path


### PR DESCRIPTION
Nobody has time to find all their git repos first! The `add-all` command
finds all git repos within the current directory and adds them to the
list of tracked repos.

For example, given the following directory structure, running
`systemgit add-all` from the `code` directory would add all of the
projects.

    code/
        project1/
        go/
            project2/
            project3/
        js/
            project4/

Note that we have to be careful not to assume that the user has called
the script `systemgit`, so `$0` is used to run `systemgit add` from each
found directory.